### PR TITLE
Fix: Failing test fix for controller

### DIFF
--- a/spec/controllers/articles_controller.rb
+++ b/spec/controllers/articles_controller.rb
@@ -37,8 +37,8 @@ describe ArticlesController do
 
 
       articles = create_list :article, 2
-      expect(json_data.length).to eq(2)
       subject
+      expect(json_data.length).to eq(2)
       articles.each_with_index do |article, index|
         expect(json_data[index]['attributes']).to eq({
           "title" => article.title,


### PR DESCRIPTION
This solves the failing test example. I also suggest name rspec files by appending them with: `_spec.rb`

So in this case it'd be: `articles_controller_spec.rb`. It's all because by default rspec runs all files with name ended with `_spec` when you run `rspec` command.

Without that you'll either need to update configuration a little bit, or always remember to specify file you want to run.